### PR TITLE
Add prettier rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -60,6 +60,12 @@
     "import/no-deprecated": "warn",
     "import/no-empty-named-blocks": "error",
     // OTHER
-    "no-console": "warn"
+    "no-console": "warn",
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ]
   }
 }


### PR DESCRIPTION
Добавил новое правило для prettier в eslintrc файл для того чтобы избежать данной ошибки: [eslint] Delete `CR` [prettier/prettier].